### PR TITLE
Add support for mapping to SortedSets destinations.

### DIFF
--- a/core/src/main/java/org/modelmapper/internal/converter/CollectionConverter.java
+++ b/core/src/main/java/org/modelmapper/internal/converter/CollectionConverter.java
@@ -19,7 +19,9 @@ import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.Set;
+import java.util.SortedSet;
 
 import org.modelmapper.internal.util.Iterables;
 import org.modelmapper.internal.util.TypeResolver;
@@ -45,7 +47,9 @@ class CollectionConverter extends IterableConverter<Object, Collection<Object>> 
   protected Collection<Object> createDestination(
       MappingContext<Object, Collection<Object>> context, int length) {
     if (context.getDestinationType().isInterface())
-      if (Set.class.isAssignableFrom(context.getDestinationType()))
+      if (SortedSet.class.isAssignableFrom(context.getDestinationType()))
+        return new TreeSet<Object>();
+      else if (Set.class.isAssignableFrom(context.getDestinationType()))
         return new HashSet<Object>();
       else
         return new ArrayList<Object>(length);

--- a/core/src/test/java/org/modelmapper/internal/converter/CollectionConverterTest.java
+++ b/core/src/test/java/org/modelmapper/internal/converter/CollectionConverterTest.java
@@ -6,9 +6,11 @@ import static org.testng.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
 
 import org.modelmapper.Asserts;
 import org.modelmapper.spi.ConditionalConverter.MatchResult;
@@ -86,6 +88,22 @@ public class CollectionConverterTest extends AbstractConverterTest {
   public void shouldConvertArrayToCollection() {
     Collection<String> source = Arrays.asList("a", "b", "c");
     assertEquals(convert(source, Collection.class), source);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertListToHashSet() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    Set<String> dest = (Set<String>) convert(source, Set.class);
+    assertTrue(dest instanceof HashSet);
+    Asserts.assertEquals(source, dest);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void shouldConvertListToSortedSet() {
+    List<String> source = Arrays.asList("a", "b", "c");
+    SortedSet<String> dest = (SortedSet<String>) convert(source, SortedSet.class);
+    assertTrue(dest instanceof SortedSet);
+    Asserts.assertEquals(source, dest);
   }
 
   public void testMatches() {


### PR DESCRIPTION
Previously the CollectionConverter was only discriminating between Lists and
Sets, instanciating an ArrayList if the destination type was a List and a
HashSet if the destination type was a Set. This failed when the destination
type was a SortedSet (HashSet is not a SortedSet).

Rather than change the HashSet to a TereSet for all Sets, a separate check has
been added for SortedSets so that the more performant HashMap is still used
generally and a TreeSet is used only when we know we need a SortedSet.

Two test cases where added. One is to test that the SortedSet mapping works.
The other is to test that HashSets are still used when a SortedSet is not
requested. This second test may not be necessary if we don't care that much
about the implementation backing the mapped property.