### PR TITLE
Prevent StringIndexOutOfBoundsException

### DIFF
--- a/core/src/main/java/org/modelmapper/convention/InexactMatcher.java
+++ b/core/src/main/java/org/modelmapper/convention/InexactMatcher.java
@@ -42,7 +42,7 @@ class InexactMatcher {
       String srcStr = src[srcStartIndex];
       String dstStr = dst[dstStartIndex];
 
-      for (int srcIndex = srcStartIndex, dstIndex = dstStartIndex, srcCharIndex = 0, dstCharIndex = 0;;) {
+      for (int srcIndex = srcStartIndex, dstIndex = dstStartIndex, srcCharIndex = 0, dstCharIndex = 0; srcStr.length() > 0 && dstStr.length() > 0;) {
         char c1 = srcStr.charAt(srcCharIndex);
         char c2 = dstStr.charAt(dstCharIndex);
 

--- a/core/src/test/java/org/modelmapper/bugs/GH143.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH143.java
@@ -6,8 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.modelmapper.AbstractTest;
-import org.modelmapper.Fixtures;
-import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.NameTokenizers;
 import org.testng.annotations.Test;
 

--- a/core/src/test/java/org/modelmapper/bugs/GH143.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH143.java
@@ -1,0 +1,39 @@
+package org.modelmapper.bugs;
+
+import static org.testng.Assert.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.Fixtures;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.NameTokenizers;
+import org.testng.annotations.Test;
+
+/**
+ * @author Andrei Zinca
+ */
+@Test
+public class GH143 extends AbstractTest {
+
+  static class Dummy {
+    public void setX(String x) { // do not remove
+    }
+  }
+
+  public void testMapping() {
+
+    modelMapper.getConfiguration().setSourceNameTokenizer(NameTokenizers.UNDERSCORE);
+
+    Map<String, String> m = new HashMap<String, String>();
+    m.put("__foo", "bar");
+
+    try {
+      modelMapper.map(m, Dummy.class);
+    } catch (Exception e) {
+      fail("should not throw exception", e);
+    }
+  }
+
+}


### PR DESCRIPTION
Hi. I started using ModelMapper one hour ago and found what looks like a bug. At first I thought I was not naming things right, but after digging a bit with the debugger I found this:

In a `Map` I have a property named `"__rid"` (comes from a db column name), and am using an underscore tokenizer. At some point in `InexactMatcher.matchTokens` the `src` array is `["","","rid"]`, so `srcStr.charAt(0)` throws the exception.

At this moment I am not sure how to run the test suite and what the convention of writing tests is. I just need this quick fix for myself for now.

Please let me know if it looks reasonable and if you need more help from my part.

Thank you for this excellent library.