### PR TITLE
Resolved #153: update the logic for determine when last destination mutator hit

### DIFF
--- a/core/src/test/java/org/modelmapper/bugs/GH153.java
+++ b/core/src/test/java/org/modelmapper/bugs/GH153.java
@@ -1,0 +1,86 @@
+package org.modelmapper.bugs;
+
+import java.util.Date;
+
+import org.modelmapper.AbstractTest;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * https://github.com/jhalterman/modelmapper/issues/153
+ */
+@Test
+public class GH153 extends AbstractTest {
+    class SkipAuditPersistMapping<S, T extends AuditPersist> extends PropertyMap<S, T>
+    {
+        @Override
+        protected void configure() {
+            skip().setCreateDate(null);
+            skip().setCreatedBy(null);
+            skip().setModifiedDate(null);
+            skip().setModifiedBy(null);
+        }
+    }
+
+    static class BoringClass {}
+
+    interface AuditPersist {
+        Date getCreateDate();
+        void setCreateDate(Date createDate);
+        String getCreatedBy();
+        void setCreatedBy(String createdBy);
+        Date getModifiedDate();
+        void setModifiedDate(Date modifiedDate);
+        String getModifiedBy();
+        void setModifiedBy(String modifiedBy);
+    }
+
+    static class AuditedClass implements AuditPersist {
+        private Date createDate;
+        private String createdBy;
+        private Date modifiedDate;
+        private String modifiedBy;
+
+        public Date getCreateDate() {
+            return createDate;
+        }
+
+        public void setCreateDate(Date createDate) {
+            this.createDate = createDate;
+        }
+
+        public String getCreatedBy() {
+            return this.createdBy;
+        }
+
+        public void setCreatedBy(String createdBy) {
+            this.createdBy = createdBy;
+        }
+
+        public Date getModifiedDate() {
+            return modifiedDate;
+        }
+
+        public void setModifiedDate(Date modifiedDate) {
+            this.modifiedDate = modifiedDate;
+        }
+
+        public String getModifiedBy() {
+            return modifiedBy;
+        }
+
+        public void setModifiedBy(String modifiedBy) {
+            this.modifiedBy = modifiedBy;
+        }
+
+    }
+
+    @Test
+    public void testMappingClassWithoutDi() {
+        modelMapper.createTypeMap(BoringClass.class, AuditedClass.class).addMappings(new SkipAuditPersistMapping<BoringClass, AuditedClass>());
+        AuditedClass auditedClass = modelMapper.map(new BoringClass(), AuditedClass.class);
+        Assert.assertNotNull(auditedClass);
+    }
+}


### PR DESCRIPTION
Resolved #153

**Reason**
At [ExplicitMappingVisitor.java#L202](https://github.com/jhalterman/modelmapper/blob/master/core/src/main/java/org/modelmapper/internal/ExplicitMappingVisitor.java#L202)
```java
if (mapType != 0 && !isAccessor(mn) && mn.owner.equals(lastMutatorOwner)) {
  recordDestinationMethod(ownerType, methodFor(ownerType, methodType, mn));
    recordProperties();
}
```
It determine current method is last destination or not by check
- not isAccessor
- the owner of the method is equal to destination type

The second part want to make sure that the method is from destination not from the source,
but it let PropertyMap which had define parent class or interface as its destination type would failed on determine last destination mutator.
So I try following modification and it seems that the result is OK.


**Modification**
update the logic for determine when last destination mutator hit, so that modelmapper could accept more generic type on destination type

1. Removed isAccessor, but introduce isMutator with more strict check by
using regex to determine that method is accessor or mutator
2. Determine last destination mutator hit without check
lastMutatorOwner, but with the strict check isMutator


I think the modification could cover scenarios on [modelmapper/Property Mapping](http://modelmapper.org/user-manual/property-mapping/)
And all unittest pass.
But I'm afraid is that is there any abnormal use case that will cause some unexpected result or different behavior with this commit.